### PR TITLE
Fix: Locale settings not applying to Claude Code conversations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ env/
 .genreleases/
 *.zip
 sdd-*/
+
+# Claude Code generated files (created by specify init)
+.claude/CLAUDE.md


### PR DESCRIPTION
## Problem

When users selected a non-English language (e.g., Korean) during `specify init`, the language setting was only applied to command templates (`.claude/commands/*.md`) but **not to real-time AI conversations** in Claude Code. This meant:

- ❌ Command templates had language instructions injected
- ❌ But Claude Code conversations still defaulted to English
- ❌ Users experienced inconsistent language behavior

## Root Cause

Language instructions were only injected into individual slash command templates, which are used when users run commands like `/specify` or `/constitution`. However, Claude Code also has regular conversations outside of these commands, and there was no mechanism to inform Claude Code about the project's language preference for general interactions.

## Solution

Generate a `.claude/CLAUDE.md` file that Claude Code automatically loads for **all conversations** in the project. This file contains:

1. **Language instructions**: Clear directives to use the selected language
2. **Guidelines**: Language-specific rules (e.g., keep code in English, translate content)
3. **Persistence**: Applied to every conversation, not just slash commands

## Changes

### 1. New Function: `create_claude_language_guide()`

- Generates `.claude/CLAUDE.md` with language-specific instructions from locale YAML files
- Skips generation for English (default language)
- Properly extracts `guidelines` as a list from locale data (fixes type conversion issue)
- Creates `.claude` directory if it doesn't exist

### 2. Integration

- `apply_language_to_commands()` now calls `create_claude_language_guide()` after processing command templates
- Ensures both slash commands AND general conversations use the correct language

### 3. `.gitignore` Update

- Added `.claude/CLAUDE.md` to `.gitignore` since it's auto-generated per-project

## Testing

Verified with `specify init --lang ko --ai claude`:

### ✅ Korean locale:

- `.claude/CLAUDE.md` generated with Korean instructions and guidelines
- All command templates contain Korean language directives
- CLI output displays in Korean

### ✅ English locale:

- No `.claude/CLAUDE.md` generated (not needed)
- Command templates remain clean without language directives
- Default English behavior maintained

## Example Generated File

`.claude/CLAUDE.md` for Korean (`--lang ko`):

```markdown
# Project Language: 한국어 (Korean)

🚨 CRITICAL INSTRUCTION - MUST FOLLOW 🚨
You MUST generate ALL content in Korean (한국어).
All sections, descriptions, requirements, and text content MUST be in Korean.
Only keep technical terms, code examples, and search keywords in English when appropriate.

**필수**: 모든 생성되는 콘텐츠를 한국어로 작성하세요.
- 모든 섹션, 설명, 요구사항, 텍스트는 한국어로 작성
- 기술 용어, 코드 예제, 웹 검색 키워드만 필요시 영어 유지
- 한국어로 작성하지 않으면 응답이 거부됩니다


언어별 가이드라인:
- 문서의 구조와 형식은 유지하되 내용은 한국어로 작성
- 기술적 용어는 필요시 영어 병기 (예: 데이터베이스 (Database))
- 코드 예제와 명령어는 영어로 유지
- 웹 검색 키워드는 검색 효율성을 위해 영어 사용 권장
- 마크다운 구문과 템플릿 구조는 변경하지 않음
```

## Files Changed

- `src/specify_cli/template_processor.py`: Add `create_claude_language_guide()` function (+67 lines)
- `.gitignore`: Ignore auto-generated `.claude/CLAUDE.md` (+3 lines)

## Related Issues

Fixes the issue where locale selection didn't affect Claude Code conversation language.

---

This PR ensures that when users select a language during project initialization, **both slash commands and regular AI conversations** respect that language setting, providing a consistent multilingual experience.
